### PR TITLE
✨feat: add mock aws credentials to conftest.py and fix scope of s3_client fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
-from moto import mock_aws
-import pytest
 import boto3
+import pytest
+from moto import mock_aws
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def s3_client():
     with mock_aws():
         client = boto3.client("s3", region_name="eu-west-2")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,22 @@
+import os
+
 import boto3
 import pytest
 from moto import mock_aws
 
 
+@pytest.fixture(scope="module", autouse=True)
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-2"
+
+
 @pytest.fixture(scope="function")
-def s3_client():
+def s3_client(aws_credentials):
     with mock_aws():
         client = boto3.client("s3", region_name="eu-west-2")
         yield client


### PR DESCRIPTION
Fix scope of s3_client fixture so all client instances used in tests are unique to that test file instead of sharing the same instance for the whole class.

Add mock AWS credentials as a fallback safeguard to make sure tests never connect to AWS services for real.