### PR TITLE
✅ test: ignore DeprecationWarning in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
 [tool.pytest.ini_options]
 addopts = "-vvv -rP --testdox"
 pythonpath = "."
+filterwarnings = "ignore::DeprecationWarning"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
- ignore DeprecationWarning to reduce noise in test output