### PR TITLE
🐛 fix: move bandit and boto3 to dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 
-dependencies = [
-    "bandit>=1.8.3",
-    "boto3>=1.38.23",
-]
+dependencies = []
 
 [dependency-groups]
 dev = [
@@ -17,6 +14,8 @@ dev = [
     "pytest-cov>=6.1.1",
     "ruff>=0.11.11",
     "moto>=5.1.5",
+    "bandit>=1.8.3",
+    "boto3>=1.38.23",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -444,13 +444,11 @@ wheels = [
 name = "royal-blue"
 version = "0.1.0"
 source = { virtual = "." }
-dependencies = [
-    { name = "bandit" },
-    { name = "boto3" },
-]
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
+    { name = "boto3" },
     { name = "moto" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -459,13 +457,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "bandit", specifier = ">=1.8.3" },
-    { name = "boto3", specifier = ">=1.38.23" },
-]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.8.3" },
+    { name = "boto3", specifier = ">=1.38.23" },
     { name = "moto", specifier = ">=5.1.5" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },


### PR DESCRIPTION
- move bandit and boto3 from dependencies to dev-dependencies
- these dependencies should not be added to dependency layers in s3