### PR TITLE
✨ feat: implement create_parquets_from_data_frames utility function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,4 +17,6 @@
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
     },
+    "ruff.format.preview": true,
+    "ruff.lint.preview": true,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
     "moto>=5.1.5",
     "bandit>=1.8.3",
     "boto3>=1.38.23",
+    "pandas>=2.2.3",
 ]
 
 [tool.pytest.ini_options]

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,10 +9,10 @@ def create_parquets_from_data_frames(data: list):
     Converts a list of data frames into in-memory Parquet files.
 
     This function receives a list of dictionaries where each dictionary represents a table
-    with metadata and a pandas DataFrame. It serializes each DataFrame into a compressed 
+    with metadata and a pandas DataFrame. It serializes each DataFrame into a compressed
     Parquet file stored in a BytesIO buffer.
 
-    If any conversion fails, the function returns an error dictionary containing the table name 
+    If any conversion fails, the function returns an error dictionary containing the table name
     and the error message. Otherwise, it returns a success dictionary with all converted files.
 
     Args:
@@ -47,41 +47,35 @@ def create_parquets_from_data_frames(data: list):
             }
     """
     parquet_files = []
-    
+
     for table in data:
-        table_name = table.get('table_name')
-        last_updated = table.get('last_updated')
-        data_frame = table.get('data_frame')
+        table_name = table.get("table_name")
+        last_updated = table.get("last_updated")
+        data_frame = table.get("data_frame")
 
         if not isinstance(data_frame, pd.DataFrame):
-            return {
-                "error": {
-                    "message": f"{table_name}: invalid data type."
-                }
-            }
+            return {"error": {"message": f"{table_name}: invalid data type."}}
 
         buffer = BytesIO()
-        
+
         try:
             data_frame.to_parquet(buffer, engine="pyarrow", compression="gzip")
             buffer.seek(0)
-            
-            parquet_files.append({
-                'table_name': table_name,
-                'last_updated': last_updated,
-                'parquet_file': buffer
-            })
-        except Exception as err:
-            return {
-                "error":{
-                    "message": f"{table_name}: {err}"
+
+            parquet_files.append(
+                {
+                    "table_name": table_name,
+                    "last_updated": last_updated,
+                    "parquet_file": buffer,
                 }
-            }
-            
+            )
+        except Exception as err:
+            return {"error": {"message": f"{table_name}: {err}"}}
+
     return {
         "success": {
             "message": "Parquet file conversion successful.",
-            "data": parquet_files
+            "data": parquet_files,
         }
     }
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,89 @@
+from io import BytesIO
+
+import pandas as pd
 from botocore.exceptions import ClientError
+
+
+def create_parquets_from_data_frames(data: list):
+    """
+    Converts a list of data frames into in-memory Parquet files.
+
+    This function receives a list of dictionaries where each dictionary represents a table
+    with metadata and a pandas DataFrame. It serializes each DataFrame into a compressed 
+    Parquet file stored in a BytesIO buffer.
+
+    If any conversion fails, the function returns an error dictionary containing the table name 
+    and the error message. Otherwise, it returns a success dictionary with all converted files.
+
+    Args:
+        data (list): A list of dictionaries, each containing:
+            - table_name (str): Name of the table.
+            - last_updated (str): ISO timestamp of the latest data update.
+            - data_frame (pandas.DataFrame): DataFrame to be serialized.
+
+    Returns:
+        dict: A JSON-style response indicating success or failure.
+
+        Success:
+            {
+                "success": {
+                    "message": "Parquet file conversion successful.",
+                    "data": [
+                        {
+                            "table_name": "example_table",
+                            "last_updated": "2025-05-27 12:00:00",
+                            "parquet_file": <_io.BytesIO>
+                        },
+                        ...
+                    ]
+                }
+            }
+
+        Error:
+            {
+                "error": {
+                    "message": "table_name: error_description"
+                }
+            }
+    """
+    parquet_files = []
+    
+    for table in data:
+        table_name = table.get('table_name')
+        last_updated = table.get('last_updated')
+        data_frame = table.get('data_frame')
+
+        if not isinstance(data_frame, pd.DataFrame):
+            return {
+                "error": {
+                    "message": f"{table_name}: invalid data type."
+                }
+            }
+
+        buffer = BytesIO()
+        
+        try:
+            data_frame.to_parquet(buffer, engine="pyarrow", compression="gzip")
+            buffer.seek(0)
+            
+            parquet_files.append({
+                'table_name': table_name,
+                'last_updated': last_updated,
+                'parquet_file': buffer
+            })
+        except Exception as err:
+            return {
+                "error":{
+                    "message": f"{table_name}: {err}"
+                }
+            }
+            
+    return {
+        "success": {
+            "message": "Parquet file conversion successful.",
+            "data": parquet_files
+        }
+    }
 
 
 def get_file_from_s3_bucket(client, bucket_name, key):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,24 +22,26 @@ def s3_client(aws_credentials):
         client = boto3.client("s3", region_name="eu-west-2")
         yield client
 
+
 @pytest.fixture(scope="function")
 def valid_data_frame_data():
     return [
         {
             "table_name": "test_table",
             "last_updated": "2025-05-27 01:23:45.678910",
-            "data_frame": pd.DataFrame({
-                "name": ["Charley", "Oliver"],
-                "age": [27, 28]
-            })
+            "data_frame": pd.DataFrame(
+                {"name": ["Charley", "Oliver"], "age": [27, 28]}
+            ),
         },
         {
             "table_name": "test_table_2",
             "last_updated": "2025-05-27 02:34:56.798101",
-            "data_frame": pd.DataFrame({
-                "country": ["Lancashire", "Greater Manchester"],
-                "city": ["Preston", "Manchester"],
-                "road": ["Victoria", "Oxford Road"]
-            })
-        }
+            "data_frame": pd.DataFrame(
+                {
+                    "country": ["Lancashire", "Greater Manchester"],
+                    "city": ["Preston", "Manchester"],
+                    "road": ["Victoria", "Oxford Road"],
+                }
+            ),
+        },
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import boto3
+import pandas as pd
 import pytest
 from moto import mock_aws
 
@@ -20,3 +21,25 @@ def s3_client(aws_credentials):
     with mock_aws():
         client = boto3.client("s3", region_name="eu-west-2")
         yield client
+
+@pytest.fixture(scope="function")
+def valid_data_frame_data():
+    return [
+        {
+            "table_name": "test_table",
+            "last_updated": "2025-05-27 01:23:45.678910",
+            "data_frame": pd.DataFrame({
+                "name": ["Charley", "Oliver"],
+                "age": [27, 28]
+            })
+        },
+        {
+            "table_name": "test_table_2",
+            "last_updated": "2025-05-27 02:34:56.798101",
+            "data_frame": pd.DataFrame({
+                "country": ["Lancashire", "Greater Manchester"],
+                "city": ["Preston", "Manchester"],
+                "road": ["Victoria", "Oxford Road"]
+            })
+        }
+    ]

--- a/tests/test_extract_lambda/test_create_parquets_from_data_frames.py
+++ b/tests/test_extract_lambda/test_create_parquets_from_data_frames.py
@@ -9,67 +9,68 @@ from src.utils import create_parquets_from_data_frames
 
 @pytest.mark.describe("create_parquets_from_data_frames Utility Function Behaviour")
 class TestCreateParquetsFromDataFrames:
-    @pytest.mark.it(
-        "check should return 'parquet_file' values as Parquet file buffers"
-    )
-    def test_returns_data_in_parquet_format(self, valid_data_frame_data):        
+    @pytest.mark.it("check should return 'parquet_file' values as Parquet file buffers")
+    def test_returns_data_in_parquet_format(self, valid_data_frame_data):
         result = create_parquets_from_data_frames(valid_data_frame_data)
 
-        data = result['success']['data']
-        
+        data = result["success"]["data"]
+
         assert "success" in result
-        assert 'Parquet file conversion successful.' == result['success']['message']
-        
+        assert "Parquet file conversion successful." == result["success"]["message"]
+
         for item in data:
             assert isinstance(item["parquet_file"], BytesIO)
-            
-    @pytest.mark.it(
-        "check should return a list of the same length as the input list"
-    )
+
+    @pytest.mark.it("check should return a list of the same length as the input list")
     def test_returns_same_number_of_files(self, valid_data_frame_data):
         result = create_parquets_from_data_frames(valid_data_frame_data)
-        
-        assert len(result['success']['data']) == len(valid_data_frame_data)
-        
+
+        assert len(result["success"]["data"]) == len(valid_data_frame_data)
+
     @pytest.mark.it(
         "check should preserve 'table_name' and 'last_updated' values in the returned output"
     )
     def test_preserves_data(self, valid_data_frame_data):
-
         result = create_parquets_from_data_frames(valid_data_frame_data)
-        data = result['success']['data']
-        for i in range (len(valid_data_frame_data)):
+        data = result["success"]["data"]
+        for i in range(len(valid_data_frame_data)):
             assert data[i]["table_name"] == valid_data_frame_data[i]["table_name"]
             assert data[i]["last_updated"] == valid_data_frame_data[i]["last_updated"]
 
-    @pytest.mark.it("check should return an error if the data_frame is not a valid DataFrame")
+    @pytest.mark.it(
+        "check should return an error if the data_frame is not a valid DataFrame"
+    )
     def test_invalid_dataframe_raises_error(self):
         broken_data = [
             {
-            "table_name": "bad_table",
-            "last_updated": "2025-01-01",
-            "data_frame": {
-                "country": ["Lancashire", "Greater Manchester"],
-                "city": ["Preston", "Manchester"],
-                "road": ["Victoria", "Oxford Road"]
+                "table_name": "bad_table",
+                "last_updated": "2025-01-01",
+                "data_frame": {
+                    "country": ["Lancashire", "Greater Manchester"],
+                    "city": ["Preston", "Manchester"],
+                    "road": ["Victoria", "Oxford Road"],
+                },
             }
-            }
-        ]        
+        ]
         result = create_parquets_from_data_frames(broken_data)
 
         assert "error" in result
-        assert result['error']['message'] == "bad_table: invalid data type."
+        assert result["error"]["message"] == "bad_table: invalid data type."
 
-    @pytest.mark.it("Should return an error if an unexpected exception is raised during conversion")
+    @pytest.mark.it(
+        "Should return an error if an unexpected exception is raised during conversion"
+    )
     def test_unexpected_exception_raised(self):
         mock_df = Mock(spec=pd.DataFrame)
         mock_df.to_parquet.side_effect = Exception("Failed Conversion")
 
-        data = [{
-            "table_name": "failed_table",
-            "last_updated": "2025-01-01",
-            "data_frame": mock_df
-        }]
+        data = [
+            {
+                "table_name": "failed_table",
+                "last_updated": "2025-01-01",
+                "data_frame": mock_df,
+            }
+        ]
 
         result = create_parquets_from_data_frames(data)
 

--- a/tests/test_extract_lambda/test_create_parquets_from_data_frames.py
+++ b/tests/test_extract_lambda/test_create_parquets_from_data_frames.py
@@ -1,0 +1,77 @@
+from io import BytesIO
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from src.utils import create_parquets_from_data_frames
+
+
+@pytest.mark.describe("create_parquets_from_data_frames Utility Function Behaviour")
+class TestCreateParquetsFromDataFrames:
+    @pytest.mark.it(
+        "check should return 'parquet_file' values as Parquet file buffers"
+    )
+    def test_returns_data_in_parquet_format(self, valid_data_frame_data):        
+        result = create_parquets_from_data_frames(valid_data_frame_data)
+
+        data = result['success']['data']
+        
+        assert "success" in result
+        assert 'Parquet file conversion successful.' == result['success']['message']
+        
+        for item in data:
+            assert isinstance(item["parquet_file"], BytesIO)
+            
+    @pytest.mark.it(
+        "check should return a list of the same length as the input list"
+    )
+    def test_returns_same_number_of_files(self, valid_data_frame_data):
+        result = create_parquets_from_data_frames(valid_data_frame_data)
+        
+        assert len(result['success']['data']) == len(valid_data_frame_data)
+        
+    @pytest.mark.it(
+        "check should preserve 'table_name' and 'last_updated' values in the returned output"
+    )
+    def test_preserves_data(self, valid_data_frame_data):
+
+        result = create_parquets_from_data_frames(valid_data_frame_data)
+        data = result['success']['data']
+        for i in range (len(valid_data_frame_data)):
+            assert data[i]["table_name"] == valid_data_frame_data[i]["table_name"]
+            assert data[i]["last_updated"] == valid_data_frame_data[i]["last_updated"]
+
+    @pytest.mark.it("check should return an error if the data_frame is not a valid DataFrame")
+    def test_invalid_dataframe_raises_error(self):
+        broken_data = [
+            {
+            "table_name": "bad_table",
+            "last_updated": "2025-01-01",
+            "data_frame": {
+                "country": ["Lancashire", "Greater Manchester"],
+                "city": ["Preston", "Manchester"],
+                "road": ["Victoria", "Oxford Road"]
+            }
+            }
+        ]        
+        result = create_parquets_from_data_frames(broken_data)
+
+        assert "error" in result
+        assert result['error']['message'] == "bad_table: invalid data type."
+
+    @pytest.mark.it("Should return an error if an unexpected exception is raised during conversion")
+    def test_unexpected_exception_raised(self):
+        mock_df = Mock(spec=pd.DataFrame)
+        mock_df.to_parquet.side_effect = Exception("Failed Conversion")
+
+        data = [{
+            "table_name": "failed_table",
+            "last_updated": "2025-01-01",
+            "data_frame": mock_df
+        }]
+
+        result = create_parquets_from_data_frames(data)
+
+        assert "error" in result
+        assert result["error"]["message"] == "failed_table: Failed Conversion"

--- a/uv.lock
+++ b/uv.lock
@@ -282,12 +282,67 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643, upload-time = "2024-09-20T13:09:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573, upload-time = "2024-09-20T13:09:28.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085, upload-time = "2024-09-20T19:02:10.451Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809, upload-time = "2024-09-20T13:09:30.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316, upload-time = "2024-09-20T19:02:13.825Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055, upload-time = "2024-09-20T13:09:33.462Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175, upload-time = "2024-09-20T13:09:35.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650, upload-time = "2024-09-20T13:09:38.685Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177, upload-time = "2024-09-20T13:09:41.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526, upload-time = "2024-09-20T19:02:16.905Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013, upload-time = "2024-09-20T13:09:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620, upload-time = "2024-09-20T19:02:20.639Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436, upload-time = "2024-09-20T13:09:48.112Z" },
 ]
 
 [[package]]
@@ -382,6 +437,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -450,6 +514,7 @@ dev = [
     { name = "bandit" },
     { name = "boto3" },
     { name = "moto" },
+    { name = "pandas" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-testdox" },
@@ -463,6 +528,7 @@ dev = [
     { name = "bandit", specifier = ">=1.8.3" },
     { name = "boto3", specifier = ">=1.38.23" },
     { name = "moto", specifier = ">=5.1.5" },
+    { name = "pandas", specifier = ">=2.2.3" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-testdox", specifier = ">=3.1.0" },
@@ -534,6 +600,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/3f/13cacea96900bbd31bb05c6b74135f85d15564fc583802be56976c940470/stevedore-5.4.1.tar.gz", hash = "sha256:3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b", size = 513858, upload-time = "2025-02-20T14:03:57.285Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/45/8c4ebc0c460e6ec38e62ab245ad3c7fc10b210116cea7c16d61602aa9558/stevedore-5.4.1-py3-none-any.whl", hash = "sha256:d10a31c7b86cba16c1f6e8d15416955fc797052351a56af15e608ad20811fcfe", size = 49533, upload-time = "2025-02-20T14:03:55.849Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- 【Functionality】This function converts a list of data frames into in-memory Parquet files.
- 【Input】It receives a list of dictionaries where each dictionary represents a table with metadata and a pandas DataFrame.
- 【Process】It serializes each DataFrame into a compressed Parquet file stored in a BytesIO buffer.
- 【Error Handling】If any conversion fails, the function returns an error dictionary containing the table name and the error message.
- 【Output】Otherwise, it returns a success dictionary with all converted files.
- 【Validation】Added unit tests to validate the function's behaviour.