### PR TITLE
👷 ci: configure bandit to scan only high severity issues

### DIFF
--- a/.github/workflows/royal-blue-ci-cd.yaml
+++ b/.github/workflows/royal-blue-ci-cd.yaml
@@ -43,7 +43,7 @@ jobs:
         run: uv run pytest --cov=src tests/
 
       - name: Run Bandit Security Scan
-        run: uv run bandit -r src
+        run: uv run bandit -r -lll src
   
   deploy-terraform:
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
- update bandit command to only include high lever security issues