### PR TITLE
🔧 chore: configure ruff to prevent automatic removal of unused imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ filterwarnings = "ignore::DeprecationWarning"
 line-length = 88
 
 [tool.ruff.lint]
+unfixable = ["F401"]
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
- set ruff's unfixable option to include "F401"
- this prevents ruff from automatically deleting unused imports