### PR TITLE
👷 ci: add database secrets to pytest workflow

### DIFF
--- a/.github/workflows/royal-blue-ci-cd.yaml
+++ b/.github/workflows/royal-blue-ci-cd.yaml
@@ -37,6 +37,12 @@ jobs:
         run: uv run ruff format --verbose .
 
       - name: Run Pytest Tests
+        env:
+          DB_USER: ${{secrets.DB_USER}}
+          DB_PASSWORD: ${{secrets.DB_PASSWORD}}
+          DB_HOST: ${{secrets.DB_HOST}}
+          DB_DATABASE: ${{secrets.DB_DATABASE}}
+          DB_PORT: ${{secrets.DB_PORT}}
         run: uv run pytest
 
       - name: Run Test Coverage


### PR DESCRIPTION
- add database secrets as environment variables to the pytest workflow
- the secrets include:
  - 【DB_USER】
  - 【DB_PASSWORD】
  - 【DB_HOST】
  - 【DB_DATABASE】
  - 【DB_PORT】