### PR TITLE
🔧 chore: adjust ruff settings for unused imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,15 +8,21 @@
         "source.fixAll.ruff": "explicit",
         "source.organizeImports.ruff": "explicit"
     },
-
     "ruff.nativeServer": "auto",
     "[python]": {
-    "editor.codeActionsOnSave": {
-        "source.fixAll": "explicit",
-        "source.organizeImports": "explicit"
-    },
-    "editor.defaultFormatter": "charliermarsh.ruff"
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+        },
+        "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "ruff.format.preview": true,
     "ruff.lint.preview": true,
+    "ruff.configuration": {
+        "lint": {
+            "unfixable": [
+                "F401"
+            ]
+        }
+    }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ filterwarnings = "ignore::DeprecationWarning"
 line-length = 88
 
 [tool.ruff.lint]
-unfixable = ["F401"]
+extend-select = ["I"]
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
- prevent ruff extension from automatically removing unused imports
- allow ruff to remove unused imports when running `ruff check --fix`
- add extend-select = ["I"] to pyproject.toml