### PR TITLE
🐛 fix(extract_lambda): add missing argument in connect_db function

### DIFF
--- a/src/lambdas/extract_lambda.py
+++ b/src/lambdas/extract_lambda.py
@@ -73,7 +73,7 @@ def lambda_handler(event: EmptyDict, context: EmptyDict):
 
     """
 
-    conn = connect_db()
+    conn = connect_db("TOTESYS")
     s3_client = boto3.client("s3")
     INGEST_ZONE_BUCKET_NAME = os.environ.get("INGEST_ZONE_BUCKET_NAME")
     LAMBDA_STATE_BUCKET_NAME = os.environ.get("LAMBDA_STATE_BUCKET_NAME")


### PR DESCRIPTION
- fix: add missing argument in connect_db function
- the connect_db function requires an argument, but it was not being passed in the lambda handler
- this commit adds the missing argument to the function call